### PR TITLE
Fix: Fixed relay update in database after SwitchingMoment

### DIFF
--- a/iec61850serversimulator/src/main/java/com/cgi/iec61850serversimulator/functionclass/Scheduler.java
+++ b/iec61850serversimulator/src/main/java/com/cgi/iec61850serversimulator/functionclass/Scheduler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.cgi.iec61850serversimulator.dataclass.Device;
+import com.cgi.iec61850serversimulator.dataclass.Relay;
 import com.cgi.iec61850serversimulator.dataclass.SwitchingMoment;
 
 /**
@@ -23,9 +24,10 @@ public class Scheduler {
     private SwitchingMomentCalculator switchingMomentCalculator;
     private static final Logger logger = LoggerFactory.getLogger(Scheduler.class);
     private Device device;
+    private DatabaseUtils databaseUtils;
 
     public Scheduler(final Device device, final SwitchingMomentCalculator switchingMomentCalculator,
-            final ScheduledThreadPoolExecutor executor) {
+            final ScheduledThreadPoolExecutor executor, DatabaseUtils databaseUtils) {
         this.executor = executor;
 
         // Should remove cancelled futures, still included .purge when
@@ -35,6 +37,7 @@ public class Scheduler {
         this.switchingMomentCalculator = switchingMomentCalculator;
         this.device = device;
         this.scheduledFutures = new ArrayList<>();
+        this.databaseUtils = databaseUtils;
     }
 
     // Base it on feature/example-scheduling code! Triggering at certain
@@ -92,6 +95,8 @@ public class Scheduler {
         return () -> {
             logger.info("Switching relay {} to {}", relayNr, switchOn ? "on" : "off");
             Scheduler.this.device.getRelay(relayNr).setLight(switchOn);
+            Relay updatedRelay = Scheduler.this.device.getRelay(relayNr);
+            Scheduler.this.databaseUtils.updateDatabaseRelay(updatedRelay);
         };
     }
 

--- a/iec61850serversimulator/src/main/java/com/cgi/iec61850serversimulator/functionclass/ServerSimulator.java
+++ b/iec61850serversimulator/src/main/java/com/cgi/iec61850serversimulator/functionclass/ServerSimulator.java
@@ -52,8 +52,7 @@ public class ServerSimulator implements CommandLineRunner {
             .buildIntParameter("port", 10102);
 
     private static final StringCliParameter modelFileParam = new CliParameterBuilder("-m")
-            .setDescription("The SCL file that contains the server's information model.")
-            .setMandatory()
+            .setDescription("The SCL file that contains the server's information model.").setMandatory()
             .buildStringParameter("model-file");
 
     private ServerSap serverSap = null;
@@ -111,9 +110,6 @@ public class ServerSimulator implements CommandLineRunner {
         final ServerWrapper serverWrapper = new ServerWrapper(this.serverSap);
         final Device device = new Device();
 
-        final Scheduler scheduler = new Scheduler(device, new SwitchingMomentCalculator(),
-                (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1));
-
         device.initalizeDevice(serverWrapper);
 
         // Comparing database with model
@@ -131,6 +127,9 @@ public class ServerSimulator implements CommandLineRunner {
             }
 
         }
+
+        final Scheduler scheduler = new Scheduler(device, new SwitchingMomentCalculator(),
+                (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1), databaseUtils);
 
         logger.info("SERVER START LISTENING");
         final EventDataListener edl = new EventDataListener(device, scheduler, databaseUtils);

--- a/iec61850serversimulator/src/test/java/com/cgi/iec61850serversimulator/SchedulerTest.java
+++ b/iec61850serversimulator/src/test/java/com/cgi/iec61850serversimulator/SchedulerTest.java
@@ -42,7 +42,7 @@ public class SchedulerTest {
         // Part 3: create a schedule and put a mock (= fake) calculator and
         // executor in it
         final Device device = null;
-        final Scheduler scheduler = new Scheduler(device, this.calculator, this.executor);
+        final Scheduler scheduler = new Scheduler(device, this.calculator, this.executor, null);
 
         // Tell the make calculator what to return
         Mockito.when(this.calculator.returnSwitchingMoments(Mockito.any(), Mockito.any())).thenReturn(switchingMoments);
@@ -60,9 +60,8 @@ public class SchedulerTest {
         // "calculateTasksForDateTime" enables us to calculate exactly how many
         // seconds in the future the switching moment should happen.
         final long expectedSwitchingAfterSeconds = 1 * 3600 + 27 * 60;
-        Mockito.verify(this.executor, Mockito.times(1))
-                .schedule(Mockito.any(Runnable.class), Mockito.eq(expectedSwitchingAfterSeconds),
-                        Mockito.eq(TimeUnit.SECONDS));
+        Mockito.verify(this.executor, Mockito.times(1)).schedule(Mockito.any(Runnable.class),
+                Mockito.eq(expectedSwitchingAfterSeconds), Mockito.eq(TimeUnit.SECONDS));
     }
 
 }


### PR DESCRIPTION
Last minute bug fix as it was found during demonstration recording:

The relay did not update after a Switching Moment went off as a few lines of code was forgotten. Now it works fine.